### PR TITLE
Allow rewriting towards static files

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,15 @@ var GulpJsonServer = function(options){
 			return this.instance;
 		}
 
+		if(this.options.rewriteRules){
+			server.use(jsonServer.rewriter(this.options.rewriteRules));
+		}
+
 		var server = jsonServer.create();
 		if (this.options.static) {
 			server.use(jsonServer.defaults({static: this.options.static}));
 		} else {
 			server.use(jsonServer.defaults());
-		}
-
-		if(this.options.rewriteRules){
-			server.use(jsonServer.rewriter(this.options.rewriteRules));
 		}
 
 		var router = jsonServer.router(this.options.data);


### PR DESCRIPTION
To allow rewriting of urls towards staticfile, the recriter should be called before the static serving.
