### PR TITLE
Option to suppress output messages from json-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release notes
 
+### v1.0.2 - add option from json-server
+* Added 'quiet' option to supress json-server log message from output.
+
 ### v1.0.1 - breaking changes
 * Fixing issue with missing files in the npm package.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-json-srv",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper for json-server for easy launching with Gulp",
   "license": "MIT",
   "repository": "https://github.com/GrafGenerator/gulp-json-server.git",
@@ -8,6 +8,9 @@
     "name": "Nikita Ivanov",
     "email": "grafgenerator@gmail.com"
   },
+  "contributors": [
+    "Raul Dinegri <dinegri@gmail.com>"
+  ],
   "engines": {
     "node": ">=0.10.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ See [samples](SAMPLES.md) for more information about usage of plugin.
 |`port`|`3000`|Port number on which json-server will listen.|
 |`rewriteRules`|`null`|A key-value pairs of rewrite rules that should be applied to server.|
 |`static`|`null`|If specified and not null, sets the static files folder and lets json-server serve static files from that folder.|
+|`quiet`|`false`|If true, Suppress json-server log messages from output.|
 
 **Important:** Note that `cumulative` and `cumulativeSession` options could be specified in `options` object, passed to `pipe()` method and they will override one set at server level.
 


### PR DESCRIPTION
This change pushes the option 'quiet' to json-server, allowing you control the suppressing of messages from output.